### PR TITLE
Add notes to top of list

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -1725,6 +1725,35 @@
 		$note.find('.text').click();
 	}
 
+	//
+	function addNoteOnClick($list, $after, $before)
+	{
+		var $note  = $('tt .note').clone();
+		var $notes = $list.find('.notes');
+
+		$note.find('.text').html('');
+		$note.addClass('brand-new');
+
+		if ($before)
+		{
+			$before.before($note);
+			$note = $before.prev();
+		}
+		else
+		if ($after)
+		{
+			$after.after($note);
+			$note = $after.next();
+		}
+		else
+		{
+			$notes.prepend($note);
+			$note = $notes.find('.note').first();
+		}
+
+		$note.find('.text').click();
+	}
+
 	function deleteNote($note)
 	{
 		$note
@@ -2557,7 +2586,7 @@
 
 	//
 	$('.board .add-note').live('click', function(){
-		addNote( $(this).closest('.list') );
+		addNoteOnClick( $(this).closest('.list') );
 		return false;
 	});
 


### PR DESCRIPTION
Hi,

I'm really enjoying using this tool! One of the frustrations I had with it was that with long lists, adding a new note to a list would create a note offscreen and then force a scroll to the bottom on typing. This change fixes that by simply adding notes to the top of lists, which is much better for my personal workflow.

I don't know if this is something that would be considered as an addition at all, especially considering that it's pretty subjective, but I've had this change sitting on my local copy for a few weeks now so I figured I might as well share.

Thanks for the great tool.