### PR TITLE
Added dark background to menus in crowded layout

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -935,7 +935,7 @@
 	}
 
 	/***/
-	.dark .config {
+	.dark .config, .dark.crowded .config:hover {
 		background-color: #15171A;
 	}
 
@@ -973,7 +973,7 @@
 		color: #ccc;
 	}
 
-	.dark .logo {
+	.dark .logo, .dark.crowded .logo:hover {
 		background: #15171A;
 	}
 


### PR DESCRIPTION
When using the dark theme in and the crowded class is applied the `config` and `logo` menus still had a white background. I've fixed this in this pull request, below is the before and after of the `config` menu.

![light-bg](https://user-images.githubusercontent.com/35942108/80953927-58d34980-8df4-11ea-8cf5-9b97da8d78d3.png)

![dark-bg](https://user-images.githubusercontent.com/35942108/80953925-57098600-8df4-11ea-9190-050e63527cc5.png)

p.s. I think this is an amazing tool, thank you for developing this.
