### PR TITLE
[WIP] Cloud Sync with Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 USER=nullboard
 PASSWD=nullboard
+PORT=3000
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PW=passwd

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+USER=nullboard
+PASSWD=nullboard
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PW=passwd

--- a/app.js
+++ b/app.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+const path = require('path');
+const basicAuth = require('express-basic-auth')
+const bodyParser = require('body-parser');
+require('dotenv').config();
+
+// app configuration
+app.use(bodyParser.urlencoded({extended: false}));
+app.use('/extras', express.static('extras'));
+
+// basic authentication
+let users = {};
+users[process.env.USERNAME] = process.env.PASSWD;
+var staticUserAuth = basicAuth({
+  users: users,
+  challenge: true
+})
+
+// initialize redis
+var redis = require('redis');
+var client = redis.createClient({ host: process.env.REDIS_HOST, port: process.env.REDIS_PORT, password: process.env.REDIS_PW });
+client.on('error', function (err) {
+  console.log('error event - ' + client.host + ':' + client.port + ' - ' + err);
+});
+client.on("connect", function () {
+  console.log("You are now connected");
+});
+
+// routes
+app.get('/', staticUserAuth, (req, res) => {
+  res.sendFile(path.join(__dirname + '/nullboard.html'));
+})
+
+app.post('/save', staticUserAuth, (req, res) => {
+  client.hmset(`nullboard.board.${req.body.boardId}`, {boardRevision: req.body.boardRevision, boardContent: req.body.boardContent}, function(err, reply) {
+    console.log(req.body.boardId);
+    console.log("Saved Successfully!");
+    res.send();
+  });
+})
+
+app.get('/delete', staticUserAuth, (req, res) => {
+  console.log(`nullboard.board.${req.query.id}`);
+  client.del(`nullboard.board.${req.query.id}`, function(err, response) {
+    if (response == 1) {
+       console.log("Deleted Successfully!");
+    } else{
+     console.log("Cannot delete");
+    }
+ })
+})
+
+app.get('/get', staticUserAuth, (req, res) => {
+  client.hgetall(`nullboard.board.${req.query.id}`, function(err, object) {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(object));
+  });
+})
+
+app.get('/getBoardIds', staticUserAuth, (req, res) => {
+  client.keys('nullboard.board.*', function(err, object){
+    console.log(object);
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(object));
+  })
+})
+
+app.listen(port, () => {
+  console.log(`Example app listening at http://localhost:${port}`);
+})

--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const app = express();
-const port = 3000;
 const path = require('path');
 const basicAuth = require('express-basic-auth')
 const bodyParser = require('body-parser');
@@ -67,6 +66,7 @@ app.get('/getBoardIds', staticUserAuth, (req, res) => {
   })
 })
 
+const port = process.env.PORT;
 app.listen(port, () => {
   console.log(`Example app listening at http://localhost:${port}`);
 })

--- a/nullboard.html
+++ b/nullboard.html
@@ -879,6 +879,14 @@
 		/* text-decoration-thickness: 2px; */
 	}
 
+	.dark .board .note.mark .text {
+		color: inherit;
+		text-shadow: 0 0 4px #0008;
+		text-decoration: line-through;
+		text-decoration-color: #f12e2e;
+		text-decoration-thickness: 1.6px;
+	}
+
 	.dark .board .note .ops .teaser {
 		color: #ccc;
 	}
@@ -1129,6 +1137,7 @@
 			<a href=# class=exp-board>Export board...</a>
 			<a href="#" class="switch-theme">Use <i>light</i><b>dark</b> theme</a>
 			<a href="#" class="switch-fsize">Use <i>smaller</i><b>larger</b> font</a>
+			<a href="#" class="clear-board">Clear Marked Notes</a>
 		</div>
 	</div>
 	</div>
@@ -1184,6 +1193,7 @@
 				<a href=# class=teaser></a>
 				<div class=bulk>
 					<a href=# class='del-note warn'><u></u></a>
+					<a href=# class='mark-note'>M</a>
 					<a href=# class='raw-note'>R</a>
 					<a href=# class='collapse'>_</a>
 				</div>
@@ -1245,6 +1255,7 @@
 	function Note(text)
 	{
 		this.text = text;
+		this.mark = false;
 		this.raw  = false;
 		this.min  = false;
 	}
@@ -1495,6 +1506,7 @@
 			list.notes.forEach(function(n){
 				var $n = $ndiv.clone();
 				setText( $n.find('.text'), n.text );
+				if (n.mark) $n.addClass('mark');
 				if (n.raw) $n.addClass('raw');
 				if (n.min) $n.addClass('collapsed');
 				$l_notes.append($n);
@@ -1518,7 +1530,7 @@
 	}
 
 	//
-	function saveBoard()
+	function saveBoard(clear_board=false)
 	{
 		var $board = $('.wrap .board');
 		var board = new Board( getText($board.find('> .head .text')) );
@@ -1529,9 +1541,15 @@
 
 			$list.find('.note').each(function(){
 				var $note = $(this)
-				var n = l.addNote( getText($note.find('.text')) );
-				n.raw = $note.hasClass('raw');
-				n.min = $note.hasClass('collapsed');
+				var ismark = $note.hasClass('mark');
+				if (clear_board && ismark){
+					;
+				}else{
+					var n = l.addNote( getText($note.find('.text')) );
+					n.mark = ismark;
+					n.raw = $note.hasClass('raw');
+					n.min = $note.hasClass('collapsed');
+				}
 			});
 		});
 
@@ -1744,34 +1762,34 @@
 	{
 		var blob =
 			'{"format":20190412,"id":1555071015420,"revision":581,"title":"Welcome to Nullboard","lists":[{"title":"The Use' +
-			'r Manual","notes":[{"text":"This is a note.\\nA column of notes is a list.\\nA set of lists is a board.","raw"' +
-			':false,"min":false},{"text":"All data is saved locally.\\nThe whole thing works completely offline.","raw":fal' +
-			'se,"min":false},{"text":"Last 50 board revisions are retained.","raw":false,"min":false},{"text":"Ctrl-Z is Un' +
-			'do  -  goes one revision back.\\nCtrl-Y is Redo  -  goes one revision forward.","raw":false,"min":false},{"tex' +
-			't":"Caveats","raw":true,"min":false},{"text":"Desktop-oriented.\\nMobile support is basically untested.","raw"' +
+			'r Manual","notes":[{"text":"This is a note.\\nA column of notes is a list.\\nA set of lists is a board.","mark":false,"raw"' +
+			':false,"min":false},{"text":"All data is saved locally.\\nThe whole thing works completely offline.","mark":false,"raw":fal' +
+			'se,"min":false},{"text":"Last 50 board revisions are retained.","mark":false,"raw":false,"min":false},{"text":"Ctrl-Z is Un' +
+			'do  -  goes one revision back.\\nCtrl-Y is Redo  -  goes one revision forward.","mark":false,"raw":false,"min":false},{"tex' +
+			't":"Caveats","mark":false,"raw":true,"min":false},{"text":"Desktop-oriented.\\nMobile support is basically untested.","mark":false,"raw"' +
 			':false,"min":false},{"text":"Works in Firefox, Chrome is supported.\\nShould work in Safari, may work in Edge.' +
-			'","raw":false,"min":false},{"text":"Still very much in beta. Caveat emptor.","raw":false,"min":false},{"text":' +
-			'"Issues and suggestions","raw":true,"min":false},{"text":"Post them on Github.\\nSee \\"Nullboard\\" at the to' +
-			'p left for the link.","raw":false,"min":false}]},{"title":"Things to try","notes":[{"text":"\u2022   Click on ' +
-			'a note to edit.","raw":false,"min":false},{"text":"\u2022   Click outside of it when done editing.\\n\u2022   ' +
-			'Alternatively, use Shift-Enter.","raw":false,"min":false},{"text":"\u2022   To discard changes press Escape.",' +
-			'"raw":false,"min":false},{"text":"\u2022   Try Ctrl-Enter, see what it does.\\n\u2022   Try Ctrl-Shift-Enter t' +
-			'oo.","raw":false,"min":false},{"text":"\u2022   Hover over a note to show its  \u2261  menu.\\n\u2022   Hover ' +
-			'over  \u2261  to reveal the options.","raw":false,"min":false},{"text":"\u2022   X  deletes the note.\\n\u2022' +
-			'   R changes how a note looks.\\n\u2022   _  collapses the note.","raw":false,"min":false},{"text":"This is a ' +
-			'raw note.","raw":true,"min":false},{"text":"This is a collapsed note. Only its first line is visible. Useful f' +
-			'or keeping lists compact.","raw":false,"min":true}, {"text":"Links","raw":true,"min":false}, {"text":"Links pu' +
-			'lse on hover and can be opened via the right-click menu  -  https://nullboard.io","raw":false,"min":false}, {"tex' +
-			't":"Pressing CapsLock highlights all links and makes them left-clickable.","raw":false,"min":false}]},{"title"' +
+			'","mark":false,"raw":false,"min":false},{"text":"Still very much in beta. Caveat emptor.","mark":false,"raw":false,"min":false},{"text":' +
+			'"Issues and suggestions","mark":false,"raw":true,"min":false},{"text":"Post them on Github.\\nSee \\"Nullboard\\" at the to' +
+			'p left for the link.","mark":false,"raw":false,"min":false}]},{"title":"Things to try","notes":[{"text":"\u2022   Click on ' +
+			'a note to edit.","mark":false,"raw":false,"min":false},{"text":"\u2022   Click outside of it when done editing.\\n\u2022   ' +
+			'Alternatively, use Shift-Enter.","mark":false,"raw":false,"min":false},{"text":"\u2022   To discard changes press Escape.",' +
+			'"mark":false,"raw":false,"min":false},{"text":"\u2022   Try Ctrl-Enter, see what it does.\\n\u2022   Try Ctrl-Shift-Enter t' +
+			'oo.","mark":false,"raw":false,"min":false},{"text":"\u2022   Hover over a note to show its  \u2261  menu.\\n\u2022   Hover ' +
+			'over  \u2261  to reveal the options.","mark":false,"raw":false,"min":false},{"text":"\u2022   X  deletes the note.\\n\u2022' +
+			'   R changes how a note looks.\\n\u2022   _  collapses the note.","mark":false,"raw":false,"min":false},{"text":"This is a ' +
+			'raw note.","mark":false,"raw":true,"min":false},{"text":"This is a collapsed note. Only its first line is visible. Useful f' +
+			'or keeping lists compact.","mark":false,"raw":false,"min":true}, {"text":"Links","mark":false,"raw":true,"min":false}, {"text":"Links pu' +
+			'lse on hover and can be opened via the right-click menu  -  https://nullboard.io","mark":false,"raw":false,"min":false}, {"tex' +
+			't":"Pressing CapsLock highlights all links and makes them left-clickable.","mark":false,"raw":false,"min":false}]},{"title"' +
 			':"More things to try","notes":[{"text":"\u2022   Drag notes around to rearrange.\\n\u2022   Works between the ' +
-			'lists too.","raw":false,"min":false},{"text":"\u2022   Click on a list name to edit.\\n\u2022   Enter to save,' +
-			' Esc to cancel.","raw":false,"min":false},{"text":"\u2022   Try adding a new list.\\n\u2022   Try deleting one' +
-			'. This  _can_  be undone.","raw":false,"min":false},{"text":"\u2022   Same for the board name.","raw":false,"m' +
-			'in":false},{"text":"Boards","raw":true,"min":false},{"text":"\u2022   Check out   \u2261   at the top right.",' +
-			'"raw":false,"min":false},{"text":"\u2022   Try adding a new board.\\n\u2022   Try switching between the boards' +
-			'.","raw":false,"min":false},{"text":"\u2022   Try deleting a board. Unlike deleting a\\n     list this  _canno' +
-			't_  be undone.","raw":false,"min":false},{"text":"\u2022   Export the board   (save to a file, as json)\\n' + 
-			'\u2022   Import the board   (load from a save)","raw":false,"min":false}]}]}';
+			'lists too.","mark":false,"raw":false,"min":false},{"text":"\u2022   Click on a list name to edit.\\n\u2022   Enter to save,' +
+			' Esc to cancel.","mark":false,"raw":false,"min":false},{"text":"\u2022   Try adding a new list.\\n\u2022   Try deleting one' +
+			'. This  _can_  be undone.","mark":false,"raw":false,"min":false},{"text":"\u2022   Same for the board name.","mark":false,"raw":false,"m' +
+			'in":false},{"text":"Boards","mark":false,"raw":true,"min":false},{"text":"\u2022   Check out   \u2261   at the top right.",' +
+			'"mark":false,"raw":false,"min":false},{"text":"\u2022   Try adding a new board.\\n\u2022   Try switching between the boards' +
+			'.","mark":false,"raw":false,"min":false},{"text":"\u2022   Try deleting a board. Unlike deleting a\\n     list this  _canno' +
+			't_  be undone.","mark":false,"raw":false,"min":false},{"text":"\u2022   Export the board   (save to a file, as json)\\n' + 
+			'\u2022   Import the board   (load from a save)","mark":false,"raw":false,"min":false}]}]}';
 
 		var demo = parseBoard(blob);
 
@@ -2729,6 +2747,12 @@
 		return false;
 	});
 
+	$('.board .mark-note').live('click', function(){
+		$(this).closest('.note').toggleClass('mark');
+		saveBoard();
+		return false;
+	});
+
 	$('.board .collapse').live('click', function(){
 		$(this).closest('.note').toggleClass('collapsed');
 		saveBoard();
@@ -2794,6 +2818,13 @@
 		var $body = $('body');
 		$body.toggleClass('z1');
 		localStorage.setItem('nullboard.fsize', $body.hasClass('z1') ? 'z1' : '');
+		return false;
+	});
+
+	$('.config .clear-board').click(function(){
+		saveBoard(clear_board=true);
+		var board_id = localStorage.getItem('nullboard.last_board');
+		openBoard(board_id);
 		return false;
 	});
 

--- a/nullboard.html
+++ b/nullboard.html
@@ -875,8 +875,8 @@
 	.dark .board .note.raw .text {
 		color: #2adc41;
 		text-shadow: 0 0 4px #0008;
-		text-decoration: line-through white;
-		text-decoration-thickness: 2px;
+		/* text-decoration: line-through white; */
+		/* text-decoration-thickness: 2px; */
 	}
 
 	.dark .board .note .ops .teaser {

--- a/nullboard.html
+++ b/nullboard.html
@@ -845,7 +845,7 @@
 
 	.dark .board .note {
 		background: #2B2C2F;
-		background: linear-gradient(#2B2C2F, #27282B);
+		background: linear-gradient(#3c3d40, #28292b);
 		box-shadow: 0 1px 3px #0005;
 		text-shadow: 0 0 4px #0008;
 	}
@@ -873,8 +873,10 @@
 	}
 
 	.dark .board .note.raw .text {
-		color: #eee;
+		color: #2adc41;
 		text-shadow: 0 0 4px #0008;
+		text-decoration: line-through white;
+		text-decoration-thickness: 2px;
 	}
 
 	.dark .board .note .ops .teaser {
@@ -1344,6 +1346,129 @@
 		if (redo) $redo.show(); else $redo.hide();
 	}
 
+	// 
+	function postBoard(data) {
+		$.ajax({
+			url: "/save",
+			type: "POST",
+			dataType : 'json',
+			data: data,
+			success: function (response) {
+				console.log('Successfully saved in cloud');
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				console.log(textStatus, errorThrown);
+			}
+    	});
+	}
+
+	function deleteBoardRemote(boardId) {
+		console.log('deleting', boardId);
+		var jqXHR = $.ajax({
+			url: `/delete?id=${boardId}`,
+			type: "GET",
+			dataType : 'json',
+			success: function (res) {
+				console.log("deleting from server");
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				console.log(textStatus, errorThrown);
+			},
+		});
+	}
+
+	function getBoard(boardId) {
+		var jqXHR = $.ajax({
+			url: `/get?id=${boardId}`,
+			type: "GET",
+			dataType : 'json',
+			success: function (res) {
+				console.log("loading from server");
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				console.log(textStatus, errorThrown);
+			},
+			async: false
+		});
+		return jqXHR.responseText;
+	}
+
+	function getBoardIds() {
+		var jqXHR = $.ajax({
+			url: `/getBoardIds`,
+			type: "GET",
+			dataType : 'json',
+			success: function (res) {
+				console.log("loading from server");
+			},
+			error: function(jqXHR, textStatus, errorThrown) {
+				console.log(textStatus, errorThrown);
+			},
+			async: false
+		});
+		return jqXHR.responseText;
+	}
+
+	function syncBoards(initNew=false){
+		var remoteBoardIds = JSON.parse(getBoardIds());
+		console.log(remoteBoardIds);
+
+		// server to client
+		for (let index = 0; index < remoteBoardIds.length; index++) {
+			const element = remoteBoardIds[index];
+			var id = element.match(/nullboard\.board\.(\d+)/)[1];
+			console.log(id);
+			syncBoard(id);
+		}
+		if (initNew && remoteBoardIds[0]){
+			var id = remoteBoardIds[0].match(/nullboard\.board\.(\d+)/)[1];
+			console.log('hjjjjjj');
+			console.log(remoteBoardIds);
+			openBoard(id);
+			console.log(id);
+		}
+		// client to server for the keys not presented in remoteBoardIds
+		for (var i=0; i<localStorage.length; i++)
+		{
+			var k = localStorage.key(i);
+			var m = k.match(/^nullboard\.board\.(\d+)$/);
+			if (m && remoteBoardIds.indexOf(`nullboard.board.${m}`) < 0){
+				syncBoard(m[1], forceUpdateServer=true);
+			}
+		}
+	}
+
+	function syncBoard(boardId, forceUpdateServer=false){
+		var oldRevision = parseInt(localStorage.getItem('nullboard.board.' + boardId));
+		var serverData = JSON.parse(getBoard(boardId));
+		var initNew;
+		if (isNaN(oldRevision)){  // local key does not exsit
+			oldRevision = 0;
+			initNew = true;
+		}
+		// console.log(serverData);
+		if (serverData == null) {  // remote key does not exsit, initiating
+			console.log("Remote key does not exsit, initiating or problem happend on server.");
+			if (forceUpdateServer){
+				uploadBoardById(boardId);
+			}
+		}else{
+			var serverRevision = parseInt(serverData.boardRevision)
+			if (serverRevision > oldRevision) {
+				console.log(`Local Data is ${serverRevision-oldRevision} revision behind of server, Updating.`);
+				serverBoardData = serverData.boardContent;
+				console.log(serverData);
+				board = parseBoard(serverBoardData);
+				updateBoardFromServer(board, oldRevision, initNew);
+				board.history = loadBoardHistory(board.id);
+				document.board = board;
+			}
+			else if (serverRevision < oldRevision){
+				alert(`Local Data is ${oldRevision-serverRevision} revision ahead of server, This should Not happen.`);
+			}
+		}
+	}
+
 	//
 	function showBoard(quick)
 	{
@@ -1424,12 +1549,39 @@
 		localStorage.setItem('nullboard.board.' + blob_id, JSON.stringify(board));
 		localStorage.setItem('nullboard.board.' + board.id, board.revision);
 		console.log('Saved nullboard.board.' + blob_id + ' of ' + board.title);
+		var data = {boardId: board.id, boardRevision: board.revision, boardContent: JSON.stringify(board)}
+		postBoard(data);
 
 		//
 		trimBoardHistory(rev_old, rev_new, 50);
 
 		updateUndoRedo();
 		updateBoardIndex();
+	}
+
+	function uploadBoardById(board_id){
+		revision = localStorage.getItem('nullboard.board.' + board_id);
+		data = localStorage.getItem(`nullboard.board.${board_id}.${revision}`);
+		var data = {boardId: board_id, boardRevision: revision, boardContent: data}
+		postBoard(data);
+	}
+
+	function updateBoardFromServer(board, oldRevision, initNew=false)
+	{	
+		var rev_new = board.revision;
+		var rev_old = oldRevision;
+		console.log('aaaaaaa', board);
+		var blob_id = board.id + '.' + board.revision;
+
+		localStorage.setItem('nullboard.board.' + blob_id, JSON.stringify(board));
+		localStorage.setItem('nullboard.board.' + board.id, board.revision);
+		console.log('Saved nullboard.board.' + blob_id + ' of ' + board.title);
+
+		if (!initNew){
+			trimBoardHistory(rev_old, rev_new, 50);
+			updateUndoRedo();
+			updateBoardIndex();
+		}
 	}
 
 	function parseBoard(blob)
@@ -1497,7 +1649,6 @@
 		}
 
 		board.history = loadBoardHistory(board.id);
-
 		return board;
 	}
 
@@ -1635,6 +1786,7 @@
 		localStorage.setItem('nullboard.board.' + demo.id, demo.revision);
 		localStorage.setItem('nullboard.last_board', demo.id);
 
+		syncBoard(demo.id, forceUpdateServer=true);
 		return demo.id;
 	}
 
@@ -1817,6 +1969,7 @@
 		closeBoard(true);
 
 		document.board = loadBoard(board_id);
+		syncBoard(board_id);
 
 		localStorage.setItem('nullboard.last_board', board_id);
 
@@ -1867,7 +2020,7 @@
 		document.board = new Board('');
 		document.board.history = [ 0 ];
 
-		localStorage.setItem('nullboard.last_board', document.board_id);
+		localStorage.setItem('nullboard.last_board', document.board.id);
 
 		showBoard(false);
 
@@ -1882,6 +2035,8 @@
 		if ($list.length && ! confirm("PERMANENTLY delete this board, all its lists and their notes?"))
 			return;
 
+		var board_id = localStorage.getItem('nullboard.last_board');
+		deleteBoardRemote(board_id);
 		nukeBoard();
 		closeBoard();
 	}
@@ -2764,8 +2919,8 @@
 		adjustLayout();
 	}
 
-	//
-	if (localStorage.getItem('nullboard.theme') == 'dark')
+	// dark theme by default
+	if (localStorage.getItem('nullboard.theme') == 'dark' || localStorage.getItem('nullboard.theme') == null)
 		$('body').addClass('dark');
 
 	if (localStorage.getItem('nullboard.fsize') == 'z1')
@@ -2773,9 +2928,16 @@
 
 	//
 	var board_id = localStorage.getItem('nullboard.last_board');
+	var synced = false;
 
-	if (board_id)
+	if (board_id){
 		document.board = loadBoard(board_id);
+		syncBoard(board_id);
+	}
+	else if(board_id == null || board_id == "undefined" || board_id == null){  // new client which is empty
+		syncBoards(initNew=true);
+		synced = true;
+	}
 
 	updateBoardIndex();
 
@@ -2791,10 +2953,14 @@
 		showBoard(true);
 	}
 
+
 	//
 	setInterval(adjustListScroller, 100);
 
 	setupListScrolling();
+	if (!synced){
+		syncBoards();
+	}
 
 </script>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "nullboard",
+  "version": "1.0.0",
+  "description": "Nullboard is a minimalist take on a kanban board / a task list manager, designed to be compact, readable and quick in use.",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yueyericardo/nullboard.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/yueyericardo/nullboard/issues"
+  },
+  "homepage": "https://github.com/yueyericardo/nullboard#readme",
+  "dependencies": {
+    "connect": "^3.7.0",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1",
+    "express-basic-auth": "^1.2.0",
+    "redis": "^3.0.2"
+  }
+}


### PR DESCRIPTION
A trial to support Cloud Sync.
May not be able to merge because of remote sync, could maintain a separate version of `nullboard.html` for local only usage?

- Basic idea is to save the current board data to redis, revisions are still in localstorage
  - Structure for each board is stored as `{nullboard.board.id: {boardRevision: intNumber, boardContent: stringData}}`
- Added a `Mark as complete` option, which cloud be cleared from the menu afterwards.  
![image](https://user-images.githubusercontent.com/9999318/102191220-1ba16080-3e87-11eb-99a9-391a7782008b.png)

#### Status:
Messy codes, but basically working.

#### Instruction
1. Install dependency
```bash
npm install
npm install pm2 -g
```
2. Create an `.env` file from `.env.example` for authentication and Redis info. (Could use https://app.redislabs.com to host and try).
3. Deploy
```bash
pm2 start app.js --name nullboard
```