### PR TITLE
Feat: add bullet shortcut for Mac users

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -4707,7 +4707,7 @@
 		}
 
 		// ctrl-shift-8
-		if (isNote && ev.key == '*' && ev.ctrlKey)
+		if (isNote && ev.key == '*' && ev.ctrlKey || isNote && ev.key == '8' && ev.metaKey && ev.shiftKey)
 		{
 			var have = this.value;
 			var pos  = this.selectionStart;


### PR DESCRIPTION
I'm using nullboard on a Mac and couldn't figure out how to add bullet
points. On line 4709 of nullboard.html, I found the shortcut for adding
bullet points on Windows. I added an OR to the conditional so it
includes the Mac's Command key.

In my OR conditional, I included both the Shift key and the 8 key. For
some reason, the asterisk key wasn't working for me. Moreover, I used
the Meta key instead of the Command key's key-code. I did this to
minimize the necessary code: the left and the right Command keys have
different key-codes, and the Command keys' key-codes are different for
each browser.

The drawback to this addition is that Windows users may unintentionally
create the event by pressing the Windows key, which is also a Meta key.