### PR TITLE
Be able to use Control instead of CapsLock to reveal links.

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -3394,7 +3394,7 @@
 			'raw note.","raw":true,"min":false},{"text":"This is a collapsed note. Only its first line is visible. Useful f' +
 			'or keeping lists compact.","raw":false,"min":true}, {"text":"Links","raw":true,"min":false}, {"text":"Links pu' +
 			'lse on hover and can be opened via the right-click menu  -  https://nullboard.io","raw":false,"min":false}, {"tex' +
-			't":"Pressing CapsLock highlights all links and makes them left-clickable.","raw":false,"min":false}]},{"title"' +
+			't":"Pressing CapsLock or Control highlights all links and makes them left-clickable.","raw":false,"min":false}]},{"title"' +
 			':"More things to try","notes":[{"text":"\u2022   Drag notes around to rearrange.\\n\u2022   Works between the ' +
 			'lists too.","raw":false,"min":false},{"text":"\u2022   Click on a list name to edit.\\n\u2022   Enter to save,' +
 			' Esc to cancel.","raw":false,"min":false},{"text":"\u2022   Try adding a new list.\\n\u2022   Try deleting one' +
@@ -4158,10 +4158,10 @@
 	function setRevealState(ev)
 	{
 		var raw = ev.originalEvent;
-		var caps = raw.getModifierState && raw.getModifierState( 'CapsLock' );
+		var do_reveal = raw.getModifierState && (raw.getModifierState( 'CapsLock' ) || raw.getModifierState( 'Control' ));
 
-		if (caps) $('body').addClass('reveal');
-		else      $('body').removeClass('reveal');
+		if (do_reveal) $('body').addClass('reveal');
+		else           $('body').removeClass('reveal');
 	}
 
 	//


### PR DESCRIPTION
My keyboard has no Windows key so my CapsLock is remapped as Windows. There is a growing convention that holding Ctrl makes links clickable when they otherwise would not be, so I added the same feature here, without removing the CapsLock option.