### PR TITLE
Improve print formatting

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -1307,11 +1307,23 @@
 
 		.board .note {
 			box-shadow: none;
-			outline: 1px solid #ccc;
+			text-shadow: none !important;
+			outline: 1px solid #888;
+		}
+		.list {
+			outline: 1px solid #555;
+
+		}
+		.board .note .raw {
+			outline: none;
+			text-shadow: none;
 		}
 
-		.board .note.raw {
-			outline: none;
+		.board .head .text a,
+		.board .note .text a {
+			color: #333;
+			text-shadow: none;
+			text-decoration: underline;
 		}
 	}
 


### PR DESCRIPTION
Underline links, use grayscale, outline lists, and turn off as much text shadow as we can. This makes nicer PDFs for sharing.
