### PR TITLE
Support "commonmark/markdown" style links

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -516,6 +516,11 @@
 		transition: none;
 	}
 
+	.board .head .text a .mdlink,
+	.board .note .text a .mdlink {
+		text-decoration: underline;
+	}
+
 	@keyframes whoomp {
 		0%   { color: inherit; }
 		30%  { color: #888;    }

--- a/nullboard.html
+++ b/nullboard.html
@@ -4031,9 +4031,15 @@
 
 		text = htmlEncode(text);
 
-		var hmmm = /\b(https?:\/\/[^\s]+)/mg;
-		text = text.replace(hmmm, function(url){
+		var hmmm = /\b(?<!\()(https?:\/\/[^\s]+)(?!\))/mg;
+		text = text.replace(hmmm, function (url) {
 			return '<a href="' + url + '" target=_blank>' + url + '</a>';
+		});
+
+		// process commonmark/markdown-style links
+		var mdlink = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/mg
+		text = text.replace(mdlink, function(match, link_text, url){
+			return '<a href="' + url + '" target=_blank class=mdlink>' + link_text + '</a>';
 		});
 
 		if ( NB.peek('fileLinks') )


### PR DESCRIPTION
That is, like this: `[link text](url)`. Useful for readability, especially when generating nullboard boards from things like gitlab issues/merge requests.

I think the better solution is probably to combine both http link processing regexes into one, instead of negative lookbehind/lookahead, but this was my first attempt. If I get a chance to do better I'll update this or submit a new PR.

I did put a second commit to  underline those links, since unlike a string starting with `https`, it's not clear that these links, once processed, are actually links in the absence of link-like formatting.