### PR TITLE
Fix: Only prime note for dragging on left mouse down

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -4874,7 +4874,8 @@
 
 	//
 	$('.wrap').on('mousedown', '.board .note .text', function(ev){
-		NB.noteDrag.prime(this.parentNode, ev);
+		if (ev.which === 1)
+			NB.noteDrag.prime(this.parentNode, ev);
 	});
 
 	$('.config').on('mousedown', 'a.load-board', function(ev){


### PR DESCRIPTION
Ensures that `event.which === 1` before priming a note for dragging.

Fixes https://github.com/apankrat/nullboard/issues/72