### PR TITLE
Allow external tools to inject backup agents

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -220,7 +220,7 @@
 		-ms-user-select: none;
 		user-select: none;
 	}
-}
+
 	/***/
 	.clearfix:after,
 	.board:after,

--- a/nullboard.html
+++ b/nullboard.html
@@ -1723,6 +1723,14 @@
 
 <script type="text/javascript">
 
+	/*
+	 * allow external tools to inject the agents data here
+	 */
+	const DEFAULT_LOCAL_AUTH = '';
+	const DEFAULT_LOCAL_HOST = 'http://127.0.0.1:10001';
+	const DEFAULT_REMOTE_HOST = '';
+	const DEFAULT_REMOTE_AUTH = '';
+
 	function AppConfig()
 	{
 		this.verLast      = null;           // last used codeVersion
@@ -2098,7 +2106,7 @@
 			var agents = conf.backups.agents;
 
 			if (agents.length != 2 ||
-			    agents[0].type != simp || agents[0].conf.base != 'http://127.0.0.1:10001' ||
+			    agents[0].type != simp || agents[0].conf.base != DEFAULT_LOCAL_HOST ||
 			    agents[1].type != simp)
 			{
 				console.log('Unexpected backup config, will re-initialize.', agents);
@@ -2108,15 +2116,15 @@
 				conf.backups.agents.push({
 					type: simp,
 					id: simp + '-' + (conf.backups.nextId++),
-					enabled: false,
-					conf: { base: 'http://127.0.0.1:10001', auth: '' }
+					enabled: DEFAULT_LOCAL_AUTH.length > 0,
+					conf: { base: DEFAULT_LOCAL_HOST, auth: DEFAULT_LOCAL_AUTH }
 				})
 
 				conf.backups.agents.push({
 					type: simp,
 					id: simp + '-' + (conf.backups.nextId++),
-					enabled: false,
-					conf: { base: '', auth: '' }
+					enabled: (DEFAULT_REMOTE_HOST.length > 0) && (DEFAULT_REMOTE_AUTH.length > 0),
+					conf: { base: DEFAULT_REMOTE_HOST, auth: DEFAULT_REMOTE_AUTH }
 				})
 
 				this.saveConfig();


### PR DESCRIPTION
I created a self contained [Nullboard docker image](https://github.com/luismedel/docker-nullboard) (html app + backup agent) using a [custom backup agent](https://github.com/luismedel/nbagent).

For the thing to work, I needed a way to inject into Nullboard the agent auth token. So I moved all the defaults for the mandatory backup agents to a set of constants, in order to use an external tool (`sed`) and modify it's values during the first container run.

I know this change is a bit ad-hoc for my needs, so feel free to discard it if you consider it doesn't fit.

Also I removed a rocgue curly brace that VSCode detected in the CSS :-)