### PR TITLE
CTRL+D, CTRL+S, CTRL+X, and Alt+RightArrow -- Enables a "Due Date", Regular "Date Stamp", Quick Note Deletion Action, Tab Indention, and a Bonus Ability to Visualize Past Due Notes (and overdue visual removal if placed in a 'Done' or 'Complete' named List).

### DIFF
--- a/nullboard.html
+++ b/nullboard.html
@@ -637,6 +637,10 @@
 		background-position: right;
 	}
 
+	.board .note.strike {
+  	text-decoration: line-through;
+	}
+
 	.board .note.collapsed .text,
 	.note-dragster.collapsed .text {
 		max-height: calc( var(--lh) * 1px );
@@ -3283,8 +3287,12 @@
 
 				//remove the coloring if its in a list with "done" or "complete"
 				var listTitle = $note.closest('.list, .head').find('.text').attr('_text');
-				if (listTitle.toLowerCase().includes("done") || listTitle.toLowerCase().includes("complete"))
-					$note.removeClass('overdue')
+				if (listTitle.toLowerCase().includes("done") || listTitle.toLowerCase().includes("complete")){
+					$note.removeClass('overdue');
+					$note.addClass('strike');
+				}
+				else
+					$note.removeClass('strike');
 			});
 		});
 
@@ -3394,8 +3402,10 @@
 				if (new Date(todayDate).getTime() > new Date(noteDate).getTime()) $n.addClass('overdue');
 
 				//remove the coloring if its in a list with "done" or "complete"
-				if (list.title.toLowerCase().includes("done") || list.title.toLowerCase().includes("complete"))
-					$n.removeClass('overdue')
+				if (list.title.toLowerCase().includes("done") || list.title.toLowerCase().includes("complete")){
+					$n.removeClass('overdue');
+					$n.addClass('strike');
+				}
 
 				if (n.raw) $n.addClass('raw');
 				if (n.min) $n.addClass('collapsed');

--- a/nullboard.html
+++ b/nullboard.html
@@ -4710,6 +4710,7 @@
 			var have = this.value;
 			var want = '[' + new Date().toLocaleDateString() + '] ' + have;
 			$this.val(want);
+			this.selectionStart = this.selectionEnd = this.value.length;
 			return false;
 		}
 

--- a/nullboard.html
+++ b/nullboard.html
@@ -4710,7 +4710,6 @@
 			var have = this.value;
 			var want = '[' + new Date().toLocaleDateString() + '] ' + have;
 			$this.val(want);
-			this.selectionStart = this.selectionEnd = pos + 2;
 			return false;
 		}
 

--- a/nullboard.html
+++ b/nullboard.html
@@ -473,7 +473,7 @@
 		box-shadow: 0 1px 2px #bbb, 0 0 1px #ddd;
 		position: relative;
 	}
-
+	
 	.board .note.dragging,
 	.board .note.dragging.raw {
 		background: #CED4DA;
@@ -630,6 +630,11 @@
 	/***/
 	.board .note.collapsed {
 		padding-bottom: 6px;
+	}
+
+	.board .note.overdue {
+		background: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgYmFzZVByb2ZpbGU9InRpbnkiIGhlaWdodD0iMjRweCIgaWQ9IkxheWVyXzEiIHZlcnNpb249IjEuMiIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+PHBhdGggZD0iTTIxLjE3MSwxNS4zOThsLTUuOTEyLTkuODU0QzE0LjQ4Myw0LjI1MSwxMy4yOTYsMy41MTEsMTIsMy41MTFzLTIuNDgzLDAuNzQtMy4yNTksMi4wMzFsLTUuOTEyLDkuODU2ICBjLTAuNzg2LDEuMzA5LTAuODcyLDIuNzA1LTAuMjM1LDMuODNDMy4yMywyMC4zNTQsNC40NzIsMjEsNiwyMWgxMmMxLjUyOCwwLDIuNzctMC42NDYsMy40MDYtMS43NzEgIEMyMi4wNDMsMTguMTA0LDIxLjk1NywxNi43MDgsMjEuMTcxLDE1LjM5OHogTTEyLDE3LjU0OWMtMC44NTQsMC0xLjU1LTAuNjk1LTEuNTUtMS41NDljMC0wLjg1NSwwLjY5NS0xLjU1MSwxLjU1LTEuNTUxICBzMS41NSwwLjY5NiwxLjU1LDEuNTUxQzEzLjU1LDE2Ljg1NCwxMi44NTQsMTcuNTQ5LDEyLDE3LjU0OXogTTEzLjYzMywxMC4xMjVjLTAuMDExLDAuMDMxLTEuNDAxLDMuNDY4LTEuNDAxLDMuNDY4ICBjLTAuMDM4LDAuMDk0LTAuMTMsMC4xNTYtMC4yMzEsMC4xNTZzLTAuMTkzLTAuMDYyLTAuMjMxLTAuMTU2bC0xLjM5MS0zLjQzOEMxMC4yODksOS45MjIsMTAuMjUsOS43MTIsMTAuMjUsOS41ICBjMC0wLjk2NSwwLjc4NS0xLjc1LDEuNzUtMS43NXMxLjc1LDAuNzg1LDEuNzUsMS43NUMxMy43NSw5LjcxMiwxMy43MTEsOS45MjIsMTMuNjMzLDEwLjEyNXoiLz48L3N2Zz4=")no-repeat, linear-gradient(to right, #ffffff, #f5071f);
+		background-position: right;
 	}
 
 	.board .note.collapsed .text,
@@ -3372,6 +3377,12 @@
 			list.notes.forEach(function(n){
 				var $n = $ndiv.clone();
 				setText( $n.find('.text'), n.text );
+
+				//Search for overdue dates and highlight them red via a new class 'overdue'
+				var noteDate = new Date(n.text.split('[').pop().split(']')[0]).toLocaleDateString();
+				var todayDate = new Date().toLocaleDateString();
+				if (new Date(todayDate).getTime() > new Date(noteDate).getTime()) $n.addClass('overdue');
+
 				if (n.raw) $n.addClass('raw');
 				if (n.min) $n.addClass('collapsed');
 				$l_notes.append($n);
@@ -4156,6 +4167,14 @@
 
 			if ($item.parent().hasClass('board'))
 				NB.board.title = text_now;
+
+				//Search for overdue dates and highlight them red via a new class 'overdue' (when editing a note)
+				var noteDate = new Date(text_now.split('[').pop().split(']')[0]).toLocaleDateString();
+				var todayDate = new Date().toLocaleDateString();
+				if (new Date(todayDate).getTime() > new Date(noteDate).getTime())
+					$item.addClass('overdue');
+				else
+					$item.removeClass('overdue');
 
 			updatePageTitle();
 			saveBoard();

--- a/nullboard.html
+++ b/nullboard.html
@@ -4722,6 +4722,16 @@
 			return false;
 		}
 
+		// Alt/Option + Right to Indent
+		if (isNote && ev.altKey && ev.key == 'ArrowRight')
+		{
+			var have = this.value;
+			var want = have + '    '; //4 spaces is a TAB
+			$this.val(want);
+			this.selectionStart = this.selectionEnd = this.value.length;
+			return false;
+		}
+
 		// tab
 		if (ev.keyCode == 9)
 		{

--- a/nullboard.html
+++ b/nullboard.html
@@ -473,7 +473,7 @@
 		box-shadow: 0 1px 2px #bbb, 0 0 1px #ddd;
 		position: relative;
 	}
-	
+
 	.board .note.dragging,
 	.board .note.dragging.raw {
 		background: #CED4DA;
@@ -3275,6 +3275,16 @@
 				var n = l.addNote( getText($note.find('.text')) );
 				n.raw = $note.hasClass('raw');
 				n.min = $note.hasClass('collapsed');
+
+				//Search for overdue dates and highlight them red via a new class 'overdue'
+				var noteDate = new Date(n.text.split('[').pop().split(']')[0]).toLocaleDateString();
+				var todayDate = new Date().toLocaleDateString();
+				if (new Date(todayDate).getTime() > new Date(noteDate).getTime()) $note.addClass('overdue');
+
+				//remove the coloring if its in a list with "done" or "complete"
+				var listTitle = $note.closest('.list, .head').find('.text').attr('_text');
+				if (listTitle.toLowerCase().includes("done") || listTitle.toLowerCase().includes("complete"))
+					$note.removeClass('overdue')
 			});
 		});
 
@@ -3377,11 +3387,15 @@
 			list.notes.forEach(function(n){
 				var $n = $ndiv.clone();
 				setText( $n.find('.text'), n.text );
-
+				
 				//Search for overdue dates and highlight them red via a new class 'overdue'
 				var noteDate = new Date(n.text.split('[').pop().split(']')[0]).toLocaleDateString();
 				var todayDate = new Date().toLocaleDateString();
 				if (new Date(todayDate).getTime() > new Date(noteDate).getTime()) $n.addClass('overdue');
+
+				//remove the coloring if its in a list with "done" or "complete"
+				if (list.title.toLowerCase().includes("done") || list.title.toLowerCase().includes("complete"))
+					$n.removeClass('overdue')
 
 				if (n.raw) $n.addClass('raw');
 				if (n.min) $n.addClass('collapsed');

--- a/nullboard.html
+++ b/nullboard.html
@@ -4260,7 +4260,7 @@
 	function setRevealState(ev)
 	{
 		var raw = ev.originalEvent;
-		var do_reveal = raw.getModifierState && (raw.getModifierState( 'CapsLock' ) || raw.getModifierState( 'Control' ));
+		var do_reveal = raw.getModifierState && (raw.getModifierState( 'CapsLock' ) || raw.getModifierState( 'Control' ) || raw.getModifierState( 'Meta' ));
 
 		if (do_reveal) $('body').addClass('reveal');
 		else           $('body').removeClass('reveal');

--- a/nullboard.html
+++ b/nullboard.html
@@ -4704,6 +4704,24 @@
 			return false;
 		}
 
+		// ctrl + D for auto date insert
+		if (isNote && ev.ctrlKey && ev.keyCode  == '68')
+		{
+			var have = this.value;
+			var want = '[' + new Date().toLocaleDateString() + '] ' + have;
+			$this.val(want);
+			this.selectionStart = this.selectionEnd = pos + 2;
+			return false;
+		}
+
+		// ctrl + X to delete note
+		if (isNote && ev.ctrlKey && ev.keyCode  == '88')
+		{
+			stopEditing($this, false, false);
+			deleteNote( $(this).closest('.note') );
+			return false;
+		}
+
 		// tab
 		if (ev.keyCode == 9)
 		{
@@ -4779,7 +4797,7 @@
 		}
 
 		// ctrl-shift-8
-		if (isNote && ev.key == '*' && ev.ctrlKey)
+		if (isNote && ev.key == '*' && ev.ctrlKey || isNote && ev.key == '8' && ev.metaKey && ev.shiftKey)
 		{
 			var have = this.value;
 			var pos  = this.selectionStart;

--- a/nullboard.html
+++ b/nullboard.html
@@ -3277,7 +3277,7 @@
 				n.min = $note.hasClass('collapsed');
 
 				//Search for overdue dates and highlight them red via a new class 'overdue'
-				var noteDate = new Date(n.text.split('[').pop().split(']')[0]).toLocaleDateString();
+				var noteDate = new Date(n.text.substring(0, n.text.indexOf(']')).split('[').pop().split(']')[0]).toLocaleDateString();
 				var todayDate = new Date().toLocaleDateString();
 				if (new Date(todayDate).getTime() > new Date(noteDate).getTime()) $note.addClass('overdue');
 
@@ -3389,7 +3389,7 @@
 				setText( $n.find('.text'), n.text );
 				
 				//Search for overdue dates and highlight them red via a new class 'overdue'
-				var noteDate = new Date(n.text.split('[').pop().split(']')[0]).toLocaleDateString();
+				var noteDate = new Date(n.text.substring(0, n.text.indexOf(']')).split('[').pop().split(']')[0]).toLocaleDateString();
 				var todayDate = new Date().toLocaleDateString();
 				if (new Date(todayDate).getTime() > new Date(noteDate).getTime()) $n.addClass('overdue');
 
@@ -4183,7 +4183,7 @@
 				NB.board.title = text_now;
 
 				//Search for overdue dates and highlight them red via a new class 'overdue' (when editing a note)
-				var noteDate = new Date(text_now.split('[').pop().split(']')[0]).toLocaleDateString();
+				var noteDate = new Date(text_now.substring(0, text_now.indexOf(']')).split('[').pop().split(']')[0]).toLocaleDateString();
 				var todayDate = new Date().toLocaleDateString();
 				if (new Date(todayDate).getTime() > new Date(noteDate).getTime())
 					$item.addClass('overdue');

--- a/nullboard.html
+++ b/nullboard.html
@@ -4737,7 +4737,7 @@
 			return false;
 		}
 
-		// ctrl + D for auto date insert
+		// ctrl + d for auto due date insert (any date in the [] will update the note ui if past due -- defaults to today)
 		if (isNote && ev.ctrlKey && ev.keyCode  == '68')
 		{
 			var have = this.value;
@@ -4747,7 +4747,17 @@
 			return false;
 		}
 
-		// ctrl + X to delete note
+		// ctrl + s for auto stamp date (stamps the current date and will not affect note ui if past due)
+		if (isNote && ev.ctrlKey && ev.keyCode  == '83')
+		{
+			var have = this.value;
+			var want = new Date().toLocaleDateString() + ': ' + have;
+			$this.val(want);
+			this.selectionStart = this.selectionEnd = this.value.length;
+			return false;
+		}
+
+		// ctrl + x to delete note
 		if (isNote && ev.ctrlKey && ev.keyCode  == '88')
 		{
 			stopEditing($this, false, false);
@@ -4755,13 +4765,14 @@
 			return false;
 		}
 
-		// Alt/Option + Right to Indent
+		// alt/option + rightarrow to tab
 		if (isNote && ev.altKey && ev.key == 'ArrowRight')
 		{
 			var have = this.value;
-			var want = have + '    '; //4 spaces is a TAB
+			var pos  = this.selectionStart;
+			var want = have.substr(0, pos) + '\u0009' + have.substr(this.selectionEnd);
 			$this.val(want);
-			this.selectionStart = this.selectionEnd = this.value.length;
+			this.selectionStart = this.selectionEnd = pos + 1;
 			return false;
 		}
 

--- a/nullboard.html
+++ b/nullboard.html
@@ -1146,6 +1146,21 @@
 		padding-right: 10px;
 	}
 
+	.overlay > div.keyboardshortcuts {
+		text-align: center;
+		padding: 50px 50px;
+		position: relative;
+	}
+
+	.overlay > div.keyboardshortcuts div {
+		position: absolute;
+		bottom: -30px;
+		left: 0;
+		width: 100%;
+		color: #fff9;
+	}
+
+
 	/***/
 
 	.overlay .backup-conf {
@@ -1561,6 +1576,7 @@
 		<div class=bulk>
 			<a href=# class=view-about>About</a>
 			<a href=# class=view-license>License</a>
+			<a href=# class=view-keyboardshortcuts>Keyboard Shortcuts</a>
 			<a href=https://nullboard.io/changes target=_blank class=view-changes>Changes</a>
 			<a href=https://nullboard.io/github  target=_blank>Github</a>
 			<a href=https://nullboard.io/twitter target=_blank>Twitter</a>
@@ -1675,6 +1691,24 @@
 			<a href=https://nullboard.io target=_blank>https://nullboard.io</a>
 			<div></div>
 		</div>
+
+		<div class=keyboardshortcuts>
+			<h1>Keyboard Shortcuts</h1>
+			<a href=#> [Tab] = Cycles through notes </a> <br>
+			<a href=#> [Control + Enter] = New note below </a> <br>
+			<a href=#> [Control + Shift + Enter] = Note above </a> <br>
+			<a href=#> [Control + D] = Due date stamp </a> <br>
+			<a href=#> [Control + S] = Date stamp </a> <br>
+			<a href=#> [Control + X] = Delete note </a> <br>
+			<a href=#> [Control + *] = • (Windows)</a> <br>
+			<a href=#> [Command + Shift + 8] = • (MacOS)</a> <br>
+			<a href=#> [Alt/Option + R] = Toggle raw mode </a> <br>
+			<a href=#> [Alt/Option + UpArrow] = Collapse </a> <br>
+			<a href=#> [Alt/Option + DownArrow] = Expand </a> <br>
+			<a href=#> [Alt/Option + RightArrow] = Indent </a> <br>
+			<a href=#> [Command] or [CapsLock] = Show links </a> <br>
+		</div>
+
 
 		<div class=license>
 		</div>
@@ -5146,6 +5180,12 @@
 	$('.view-about').click(function(){
 		var $div = $('tt .about').clone();
 		$div.find('div').html(`Version ${NB.codeVersion}`);
+		showOverlay($div);
+		return false;
+	});
+
+	$('.view-keyboardshortcuts').click(function(){
+		var $div = $('tt .keyboardshortcuts').clone();
 		showOverlay($div);
 		return false;
 	});


### PR DESCRIPTION
I wanted a way to quickly add the date to the front of a note and also indent the text since Tab is used to cycle notes.  I have enabled 'due date' & regular date stamp insertion with ctrl+d & ctrl+s and the ability to indent with Alt+ArrowRight.  I also added a quick delete of a note with ctrl+x (as you do with the ability to quickly add a new note before or after current note).

In this PR I also added the Command+shift+* for the MacOS bullet bug but feel free to remove that.